### PR TITLE
Updated readme usage instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,36 @@
-# pack_17
-a resource pack for group 17!
+# Pack 17
 
-## usage
-Compress `/assets`, `pack.png` and `pack.mcmeta` into a zip file. Then put that zipfile in your .minecraft/resourcepacks. In-game, select the resource pack and enable it.
+A resource pack for Group 17!
 
-## contribution
+## Usage
+
+Download the latest release from the [releases page](https://github.com/blooburry/pack_17/releases) and put it in your resourcepacks folder. If you want to use the latest version, follow the instructions below.
+
+### Windows
+
+If you have git installed, you can clone the repository directly into your resourcepacks folder:
+
+```bat
+cd %appdata%\.minecraft\resourcepacks
+git clone git@github.com:blooburry/pack_17.git
+```
+
+Otherwise, you can download the repository as a zip file and extract it into your resourcepacks folder. You can do this by clicking the green "Code" button on the [repository page](https://github.com/blooburry/pack_17) and selecting "Download ZIP".
+
+### Mac
+
+```bash
+cd ~/Library/Application\ Support/minecraft/resourcepacks
+git clone git@github.com:blooburry/pack_17.git
+```
+
+### Linux (seriously, do you need to ask?)
+
+```bash
+cd ~/.minecraft/resourcepacks
+git clone git@github.com:blooburry/pack_17.git
+```
+
+## Contribution
+
 pls yes uwu


### PR DESCRIPTION
The whole compressing thing is really useless and too complicated for no reason. If people want the bleeding edge they can just clone the repo in their resourcepacks folder, and otherwise we'll make compressed releases that they can paste in their resourcepacks folder.